### PR TITLE
Play nicely when behind other proxies

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -104,10 +104,20 @@ Worker.prototype.runServer = function (config) {
         if (remoteAddr.slice(0, 2) !== '::') {
             remoteAddr = '::ffff:' + remoteAddr;
         }
-        req.headers['x-real-ip'] = remoteAddr;
+        // Play nicely when behind other proxies
+        if (req.headers['x-forwarded-for']) {
+            remoteAddr = req.headers['x-forwarded-for'] + ',' + remoteAddr;
+        }
         req.headers['x-forwarded-for'] = remoteAddr;
-        req.headers['x-forwarded-protocol'] = req.connection.pair ? 'https' : 'http';
-        req.headers['x-forwarded-port'] = req.connection.pair ? '443' : '80';
+        if (!req.headers['x-real-ip']) {
+            req.headers['x-real-ip'] = remoteAddr;
+        }
+        if (!req.headers['x-forwarded-protocol']) {
+            req.headers['x-forwarded-protocol'] = req.connection.pair ? 'https' : 'http';
+        }
+        if (!req.headers['x-forwarded-port']) {
+            req.headers['x-forwarded-port'] = req.connection.pair ? '443' : '80';
+        }
     };
 
     var getRemoteAddress = function (req) {


### PR DESCRIPTION
My situation is that I'm running Hipache behind Nginx and then Varnish -- I know it's complicated, but Nginx is for SSL offloading, Varnish is (obviously) for caching, and then Hipache is for load-balancing/failover.

I need the remote (source) IP address to hit the app server, and Hipache was previously only sending the address of the last proxy (which was Varnish).

My implementation changes both the X-Forwarded-For header and the X-Real-IP header. I haven't gone to the effort of converting address to IPv6 -- I wasn't sure why that was being done, I can do another version if that's essential.

Also, I couldn't get the test suite running... I kept getting "Error: Cannot find module 'redis'", which doesn't make much sense. Oh well, I'm pretty new to Node.

Cheers,

Matt
