### PR TITLE
Allow falling back on a single wildcard entry if no other frontends exist.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -113,6 +113,7 @@ Cache.prototype.getBackendFromHostHeader = function (host, callback) {
         var multi = this.redisClient.multi();
         multi.lrange('frontend:' + hostKey, 0, -1);
         multi.lrange('frontend:*' + this.getDomainName(hostKey), 0, -1);
+        multi.lrange('frontend:*', 0, -1);
         multi.smembers('dead:' + hostKey);
         multi.exec(function (err, rows) {
             this.lru.set(hostKey, rows);
@@ -125,8 +126,12 @@ Cache.prototype.getBackendFromHostHeader = function (host, callback) {
         if (backends.length === 0) {
             // The frontend does not exist, let's try the wildcard entry?
             backends = rows[1];
+            if (backends.length === 0) {
+                // Final attempt, the catch-all wildcard.
+                backends = rows[2];
+            }
         }
-        var deads = rows[2];
+        var deads = rows[3];
         if (backends.length === 0) {
             return callback('frontend not found', 400);
         }


### PR DESCRIPTION
Should be pretty self-explanatory. My application only has one "frontend" and uses Host headers to figure out what content to serve.
