### PR TITLE
Add hipache version in the debug headers

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var fs = require('fs'),
+    readInstalled = require('read-installed'),
     util = require('util'),
     http = require('http'),
     https = require('https'),
@@ -10,6 +11,11 @@ var fs = require('fs'),
     memoryMonitor = require('./memorymonitor');
 
 var rootDir = fs.realpathSync(__dirname + '/../');
+
+var versions = {};
+readInstalled(rootDir, null, null, function(err, data) {
+    versions[data.name] = data.version;
+});
 
 var logType = {
     log: 1,
@@ -181,6 +187,7 @@ Worker.prototype.runServer = function (config) {
             };
             if (res.debug === true) {
                 headers['x-debug-error'] = message;
+                headers['x-debug-version-hipache'] = versions.hipache;
             }
             res.writeHead(code, headers);
             stream.on('data', function (data) {
@@ -204,6 +211,7 @@ Worker.prototype.runServer = function (config) {
             };
             if (res.debug === true) {
                 headers['x-debug-error'] = message;
+                headers['x-debug-version-hipache'] = versions.hipache;
             }
             res.writeHead(code, headers);
             res.write(message);
@@ -297,6 +305,7 @@ Worker.prototype.runServer = function (config) {
                 }
                 // If debug is enabled, let's inject the debug headers
                 if (res.debug === true) {
+                    res.setHeader('x-debug-version-hipache', versions.hipache);
                     res.setHeader('x-debug-backend-url', req.meta.backendUrl);
                     res.setHeader('x-debug-backend-id', req.meta.backendId);
                     res.setHeader('x-debug-vhost', req.meta.virtualHost);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "hipache",
-    "version" : "0.2.3",
+    "version" : "0.2.4",
     "description" : "Complete high-scaled reverse-proxy solution",
     "keywords": [
         "reverse",
@@ -16,6 +16,7 @@
         "lib" : "./lib"
     },
     "dependencies" : {
+        "read-installed" : "0.2.2",
         "http-proxy" : "git://github.com/samalba/node-http-proxy",
         "redis" : "0.8.x",
         "lru-cache": "2.2.x",


### PR DESCRIPTION
This would be very useful for people with lots of Hipache frontends in production, to check that they are running coherent version (with e.g. an external Nagios probe).
