### PR TITLE
Simplify error pages styles

### DIFF
--- a/static/error_400.html
+++ b/static/error_400.html
@@ -2,20 +2,15 @@
   <head>
     <title>No Application Configured</title>
     <style>
-      body { background-color: #dedede; margin: 0; }
-      h1 { padding: 280px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
-      h2 { padding: 5px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
+      body { background-color: #fff; margin: 0px; padding-top: 280px; text-align: center; }
+      h1   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
+      h2   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
     </style>
   </head>
   <body>
-    <center><div style="width: 530px; height: 434px; background-image: url(http://static.dotcloud.com/proxy/warning.png); margin: 25px auto;">
-      <h1>
-        No Application Configured
-      </h1>
-      <h2>
-        This domain is not associated with an application.
-      </h2>
-      <a href="http://www.dotcloud.com/"><img src="http://static.dotcloud.com/proxy/logo.png" style="margin-top: 50px; border: 0;" /></a>
-    </div></center>
+    <div class="message">
+      <h1>No Application Configured</h1>
+      <h2>This domain is not associated with an application.</h2>
+    </div>
   </body>
 </html>

--- a/static/error_502.html
+++ b/static/error_502.html
@@ -2,19 +2,15 @@
   <head>
     <title>Error 502 - Application Not Responding</title>
     <style>
-      body { background-color: #dedede; margin: 0; }
-      h1 { padding: 280px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
-      h2 { padding: 5px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
+      body { background-color: #fff; margin: 0px; padding-top: 280px; text-align: center; }
+      h1   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
+      h2   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
     </style>
   </head>
   <body>
-    <center><div style="width: 530px; height: 434px; background-image: url(http://static.dotcloud.com/proxy/warning.png); margin: 25px auto;">
-      <h1>
-        Application Not Responding
-      </h1>
-      <h2>
-        Please try again in a few moments.
-      </h2>
-    </div></center>
+    <div class="message">
+      <h1>Application Not Responding</h1>
+      <h2>Please try again in a few moments.</h2>
+    </div>
   </body>
 </html>

--- a/static/error_504.html
+++ b/static/error_504.html
@@ -2,19 +2,15 @@
   <head>
     <title>Error 504 - Application Not Responding</title>
     <style>
-      body { background-color: #dedede; margin: 0; }
-      h1 { padding: 280px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
-      h2 { padding: 5px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
+      body { background-color: #fff; margin: 0px; padding-top: 280px; text-align: center; }
+      h1   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
+      h2   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
     </style>
   </head>
   <body>
-    <center><div style="width: 530px; height: 434px; background-image: url(http://static.dotcloud.com/proxy/warning.png); margin: 25px auto;">
-      <h1>
-        Application Not Responding
-      </h1>
-      <h2>
-        Please try again in a few moments.
-      </h2>
-    </div></center>
+    <div class="message">
+      <h1>Application Not Responding</h1>
+      <h2>Please try again in a few moments.</h2>
+    </div>
   </body>
 </html>

--- a/static/error_default.html
+++ b/static/error_default.html
@@ -2,19 +2,15 @@
   <head>
     <title>Error 502 - Application Not Responding</title>
     <style>
-      body { background-color: #dedede; margin: 0; }
-      h1 { padding: 280px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
-      h2 { padding: 5px 0 0 0; margin: 0; text-align: center; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
+      body { background-color: #fff; margin: 0px; padding-top: 280px; text-align: center; }
+      h1   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
+      h2   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
     </style>
   </head>
   <body>
-    <center><div style="width: 530px; height: 434px; background-image: url(http://static.dotcloud.com/proxy/warning.png); margin: 25px auto;">
-      <h1>
-        Application Not Responding
-      </h1>
-      <h2>
-        Please try again in a few moments.
-      </h2>
-    </div></center>
+    <div class="message">
+      <h1>Application Not Responding</h1>
+      <h2>Please try again in a few moments.</h2>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Deployed hipache on our network today and was surprised that 
image assets were served directly off dotcloud. Was that intended ?
If so you can close the PR, otherwise i made a few tweaks to pages. 

Now they dont have any image assets at all, just plain page. 
I can add link to dotcloud site if necessary. 

Example:

![Title](http://cl.ly/image/3R2Q2M2T0J3e/Screen%20Shot%202013-10-08%20at%207.48.07%20PM.png)
