### PR TITLE
Update the Dockerfile node version from 0.8.23 to 0.8.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ from	ubuntu:12.04
 run	echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 run	apt-get -y update
 run	apt-get -y install wget git redis-server supervisor
-run	wget -O - http://nodejs.org/dist/v0.8.23/node-v0.8.23-linux-x64.tar.gz | tar -C /usr/local/ --strip-components=1 -zxv
+run	wget -O - http://nodejs.org/dist/v0.8.26/node-v0.8.26-linux-x64.tar.gz | tar -C /usr/local/ --strip-components=1 -zxv
 run	npm install hipache -g
 run	mkdir -p /var/log/supervisor
 add	./supervisord.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
Given the recent security advisory about versions < 0.8.26 regarding HTTP server memory exhaustion and the likelihood that people will have public facing Hipache instances we should bump the version. Safety first!
