### PR TITLE
Converted dependency to use a public access method

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies" : {
         "read-installed" : "0.2.2",
-        "http-proxy" : "git://github.com/samalba/node-http-proxy",
+        "http-proxy" : "https://github.com/samalba/node-http-proxy.git",
         "redis" : "0.8.x",
         "lru-cache": "2.2.x",
         "optimist": "0.3.x"


### PR DESCRIPTION
Installing this service using `npm install hipache -g` fails with the following error:

```
npm ERR! git clone git://github.com/samalba/node-http-proxy Cloning into bare repository '/root/.npm/_git-remotes/git-github-com-samalba-node-http-proxy-8bbffc33'...
npm ERR! git clone git://github.com/samalba/node-http-proxy 
npm ERR! git clone git://github.com/samalba/node-http-proxy fatal: unable to connect to github.com:
npm ERR! git clone git://github.com/samalba/node-http-proxy github.com[0: 192.30.252.131]: errno=Connection refused
npm ERR! Error: Command failed: fatal: unable to connect to github.com:
npm ERR! github.com[0: 192.30.252.131]: errno=Connection refused
```

It was determined that this was caused because of the use of SSH / git backend:

```
[user@host ~]$ git clone git://github.com/samalba/node-http-proxy
Cloning into 'node-http-proxy'...
fatal: unable to connect to github.com:
github.com[0: 192.30.252.130]: errno=Connection refused
```

Changing this to use the public http protocol access allows the cloning to work:

```
[user@host ~]$ git clone https://github.com/samalba/node-http-proxy.git    
Cloning into 'node-http-proxy'...
remote: Counting objects: 2810, done.
remote: Compressing objects: 100% (1734/1734), done.
remote: Total 2810 (delta 1329), reused 2444 (delta 999)
Receiving objects: 100% (2810/2810), 746.51 KiB | 0 bytes/s, done.
Resolving deltas: 100% (1329/1329), done.
```

It is generally a best practice to use the public method of access.
