### PR TITLE
fix path of configFile for when SETTINGS_FLAVOR is defined

### DIFF
--- a/bin/hipache
+++ b/bin/hipache
@@ -35,7 +35,7 @@ if (argv.c || argv.config) {
 } else {
     config = (function (configFile) {
         if (process.env.SETTINGS_FLAVOR !== undefined) {
-            path = configFile.replace(/\.json$/, '_' + process.env.SETTINGS_FLAVOR + '.json');
+            configFile = configFile.replace(/\.json$/, '_' + process.env.SETTINGS_FLAVOR + '.json');
         }
         util.log('Loading config from ' + configFile);
         var data = fs.readFileSync(configFile);


### PR DESCRIPTION
Before the fix, this little bug will always use the default config.json even if SETTINGS_FLAVOR is defined.
