### PR TITLE
Merge IPv4 and IPv6 createServer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ backend.
             "workers": 5,
             "maxSockets": 100,
             "deadBackendTTL": 30,
-            "address": ["127.0.0.1"],
-            "address6": ["::1"],
+            "address": ["127.0.0.1", "::1"],
             "https": {
                 "port": 443,
                 "key": "/etc/ssl/ssl.key",
@@ -65,8 +64,7 @@ master process does not serve any request)
 each backend (per worker)
 * __server.deadBackendTTL__: The number of seconds a backend is flagged as
 `dead' before retrying to proxy another request to it
-* __server.address__: IPv4 Addresses  listening (HTTP and HTTPS)
-* __server.address6__: IPv6 Addresses  listening (HTTP and HTTPS)
+* __server.address__: IPv4 and IPv6 Addresses listening (HTTP and HTTPS)
 * __server.https__: SSL configuration (omit this section to disable HTTPS)
 * __driver__: Redis url (you can omit this entirely to use the local redis on the default port)
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -433,48 +433,26 @@ Worker.prototype.runServer = function (config) {
     proxy.on('error', proxyErrorHandler);
     proxy.on('start', startHandler);
 
-    // Ipv4
+    //http
     (function () {
-        var ipv4HttpServer;
+        var httpServer;
 
         if (config.address) {
             var length = config.address.length;
             for (var i = 0; i < length; i++) {
-                ipv4HttpServer = http.createServer(httpRequestHandler);
-                ipv4HttpServer.on('connection', tcpConnectionHandler);
-                ipv4HttpServer.on('upgrade', wsRequestHandler);
-                ipv4HttpServer.listen(config.port, config.address[i]);
-                monitor.addServer(ipv4HttpServer);
+                httpServer = http.createServer(httpRequestHandler);
+                httpServer.on('connection', tcpConnectionHandler);
+                httpServer.on('upgrade', wsRequestHandler);
+                httpServer.listen(config.port, config.address[i]);
+                monitor.addServer(httpServer);
             }
             return;
         }
-        ipv4HttpServer = http.createServer(httpRequestHandler);
-        ipv4HttpServer.on('connection', tcpConnectionHandler);
-        ipv4HttpServer.on('upgrade', wsRequestHandler);
-        ipv4HttpServer.listen(config.port);
-        monitor.addServer(ipv4HttpServer);
-    })();
-
-    // Ipv6
-    (function () {
-        var ipv6HttpServer;
-
-        if (config.address6) {
-            var length = config.address6.length;
-            for (var i = 0; i < length; i++) {
-                ipv6HttpServer = http.createServer(httpRequestHandler);
-                ipv6HttpServer.on('connection', tcpConnectionHandler);
-                ipv6HttpServer.on('upgrade', wsRequestHandler);
-                ipv6HttpServer.listen(config.port, config.address6[i]);
-                monitor.addServer(ipv6HttpServer);
-            }
-            return;
-        }
-        ipv6HttpServer = http.createServer(httpRequestHandler);
-        ipv6HttpServer.on('connection', tcpConnectionHandler);
-        ipv6HttpServer.on('upgrade', wsRequestHandler);
-        ipv6HttpServer.listen(config.port, '::1');
-        monitor.addServer(ipv6HttpServer);
+        httpServer = http.createServer(httpRequestHandler);
+        httpServer.on('connection', tcpConnectionHandler);
+        httpServer.on('upgrade', wsRequestHandler);
+        httpServer.listen(config.port, '::');
+        monitor.addServer(httpServer);
     })();
 
     //https
@@ -483,48 +461,29 @@ Worker.prototype.runServer = function (config) {
             return;
         }
 
-        var ipv4HttpsServer,
-            ipv6HttpsServer,
+        var httpsServer,
             i,
             length,
             options = config.https;
         options.key = fs.readFileSync(options.key, 'utf8');
         options.cert = fs.readFileSync(options.cert, 'utf8');
 
-        //https ipv4
         if (config.address) {
             length = config.address.length;
             for (i = 0; i < length; i++) {
-                ipv4HttpsServer = https.createServer(options, httpRequestHandler);
-                ipv4HttpsServer.on('connection', tcpConnectionHandler);
-                ipv4HttpsServer.on('upgrade', wsRequestHandler);
-                ipv4HttpsServer.listen(config.https.port, config.address[i]);
-                monitor.addServer(ipv4HttpsServer);
+                httpsServer = https.createServer(options, httpRequestHandler);
+                httpsServer.on('connection', tcpConnectionHandler);
+                httpsServer.on('upgrade', wsRequestHandler);
+                httpsServer.listen(config.https.port, config.address[i]);
+                monitor.addServer(httpsServer);
             }
         } else {
-            ipv4HttpsServer = https.createServer(options, httpRequestHandler);
-            ipv4HttpsServer.on('connection', tcpConnectionHandler);
-            ipv4HttpsServer.on('upgrade', wsRequestHandler);
-            ipv4HttpsServer.listen(config.https.port);
+            httpsServer = https.createServer(options, httpRequestHandler);
+            httpsServer.on('connection', tcpConnectionHandler);
+            httpsServer.on('upgrade', wsRequestHandler);
+            httpsServer.listen(config.https.port, '::');
 
-            monitor.addServer(ipv4HttpsServer);
-        }
-        //https ipv6
-        if (config.address6) {
-            length = config.address6.length;
-            for (i = 0; i < length; i++) {
-                ipv6HttpsServer = https.createServer(options, httpRequestHandler);
-                ipv6HttpsServer.on('connection', tcpConnectionHandler);
-                ipv6HttpsServer.on('upgrade', wsRequestHandler);
-                ipv6HttpsServer.listen(config.https.port, config.address6[i]);
-                monitor.addServer(ipv6HttpsServer);
-            }
-        } else {
-            ipv6HttpsServer = https.createServer(options, httpRequestHandler);
-            ipv6HttpsServer.on('connection', tcpConnectionHandler);
-            ipv6HttpsServer.on('upgrade', wsRequestHandler);
-            ipv6HttpsServer.listen(config.https.port, '::1');
-            monitor.addServer(ipv6HttpsServer);
+            monitor.addServer(httpsServer);
         }
     })();
 };


### PR DESCRIPTION
Bind to all interfaces on both IPv4 and IPv6.
Before this commit, the default behaviour was to bind to all IPv4 interfaces,
but only the local `::1` interface on IPv6.

This pull request is the result of trying to bind to all interfaces on both IPv4 and IPv6.
I tried using the following config:

```
{
  server: {
    port: 80,
    address: ["0.0.0.0"],
    address6: ["::"]
  }
}
```

…but it gave me errors:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: listen EADDRINUSE
    at errnoException (net.js:904:11)
    at Server._listen2 (net.js:1042:14)
    at net.js:1089:14
    at Object.<anonymous> (cluster.js:592:5)
    at handleResponse (cluster.js:171:41)
    at respond (cluster.js:192:5)
    at handleMessage (cluster.js:202:5)
    at process.EventEmitter.emit (events.js:117:20)
    at handleMessage (child_process.js:318:10)
    at child_process.js:392:7
2 Apr 16:19:48 - Worker died (pid: 5902, suicide: false, exitcode: 8). Spawning a new one.
```
