### PR TITLE
Improve memory monitor to allow graceful exit (without breaking existing requests).

### DIFF
--- a/lib/memorymonitor.js
+++ b/lib/memorymonitor.js
@@ -50,12 +50,12 @@ MemoryMonitor.prototype.tick = function () {
     }
     // Limit reached, starting the exit phase
     var msg = 'Memory limit exceeded (' + Math.round(currentMemory / (1024 * 1024)) + 'MB), ';
-    if (this._exited == false) {
+    if (this._exited === true) {
+        this.log(msg + 'waiting for requests to complete...');
+    } else {
         this.log(msg + 'calling exit...');
         this.exit();
         this._exited = true;
-    } else {
-        this.log(msg + 'waiting for requests to complete...');
     }
 };
 
@@ -70,8 +70,7 @@ MemoryMonitor.prototype.dumpStatistics = function () {
 };
 
 MemoryMonitor.prototype.exit = function () {
-    var n = this._servers.length,
-        i;
+    var n = this._servers.length;
 
     this.log('Waiting for ' + n + ' server handlers...');
     if (n === 0) {
@@ -110,7 +109,7 @@ MemoryMonitor.prototype.addServer = function (server) {
             return;
         }
         // All servers closed, exiting the current process
-        this.log('All server handlers finished processing requests, clean exit.')
+        this.log('All server handlers finished processing requests, clean exit.');
         this.dumpStatistics();
         cluster.worker.destroy();
     }.bind(this));


### PR DESCRIPTION
Fixes: #98 (safe workaround).

This is what it looks like: https://gist.github.com/samalba/dc27a4a7000bff194187

@shin- Could you test the branch locally and report back what you have with docker-registry?

Finally I decided not to make this configurable from the config, since I think it should be the default for people (open for discussion...).
