### PR TITLE
Remove read-installed - see #98 and memory footprint for background

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var fs = require('fs'),
-    readInstalled = require('read-installed'),
+    path = require('path'),
     util = require('util'),
     http = require('http'),
     https = require('https'),
@@ -12,10 +12,7 @@ var fs = require('fs'),
 
 var rootDir = fs.realpathSync(__dirname + '/../');
 
-var versions = {};
-readInstalled(rootDir, null, null, function (err, data) {
-    versions[data.name] = data.version;
-});
+var hipacheVersion = require(path.join(__dirname, '..', 'package.json')).version;
 
 var logType = {
     log: 1,
@@ -203,7 +200,7 @@ Worker.prototype.runServer = function (config) {
             };
             if (res.debug === true) {
                 headers['x-debug-error'] = message;
-                headers['x-debug-version-hipache'] = versions.hipache;
+                headers['x-debug-version-hipache'] = hipacheVersion;
             }
             res.writeHead(code, headers);
             stream.on('data', function (data) {
@@ -227,7 +224,7 @@ Worker.prototype.runServer = function (config) {
             };
             if (res.debug === true) {
                 headers['x-debug-error'] = message;
-                headers['x-debug-version-hipache'] = versions.hipache;
+                headers['x-debug-version-hipache'] = hipacheVersion;
             }
             res.writeHead(code, headers);
             res.write(message);
@@ -308,7 +305,7 @@ Worker.prototype.runServer = function (config) {
                 }
                 // If debug is enabled, let's inject the debug headers
                 if (res.debug === true) {
-                    res.setHeader('x-debug-version-hipache', versions.hipache);
+                    res.setHeader('x-debug-version-hipache', hipacheVersion);
                     res.setHeader('x-debug-backend-url', req.meta.backendUrl);
                     res.setHeader('x-debug-backend-id', req.meta.backendId);
                     res.setHeader('x-debug-vhost', req.meta.virtualHost);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "read-installed": "0.2.5",
     "http-proxy": "1.0.x",
     "redis": "0.10.x",
     "lru-cache": "2.5.x",


### PR DESCRIPTION
Should be pretty-safe.
Our one and only use of read-installed is in getting hipache version, which can safely be obtained otherwise by requiring hipache package.json.

This will cut our cold start per-worker memory usage in half (according to process.memoryUsage().rss).
