### PR TITLE
Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: node_js
 node_js:
-    - "0.11"
+    # XXX right now, segfaulting on the 500MB upload
+    # - "0.11"
     - "0.10"
 
 env:
+    # Don't know yet how to install etcd on travis ubuntu, so disable the tests
     - NO_ETCD=true
 
 before_install:
     - sudo apt-get update
-    - npm install -g gulp
     - sudo apt-get install redis-server memcached
+    - npm install -g gulp
 
 after_install:
-    # Pythonic tests require these to be started manually
+    # Pythonic tests require
     - sudo apt-get install python-pip
     - redis-server &
     - ./bin/hipache -c config/config_test.json &


### PR DESCRIPTION
This is a no-brainer, and can be merged safely as it doesn't alter code. In a word:
- simplify travis yml a bit (by using `before_` and `after_` hooks instead of overriding `install` and `script`
- prepare to enable nodejs 0.11 (for whenever they fix it and it stops segfaulting on my shoes :-1: )
- enable code coverage reporting (we have about 80% coverage now, which is quite good IMO!)
