### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/dotcloud/hipache.png?label=ready&title=Ready)](https://waffle.io/dotcloud/hipache)
 Hipache: a distributed HTTP and websocket proxy
 ===============================================
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/dotcloud/hipache

This was requested by a real person (user dmp42) on waffle.io, we're not trying to spam you.
