### PR TITLE
Zookeeper driver support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install redis-server memcached
     - npm install -g gulp
+    # Zookeeper install
+    - pushd $HOME
+    - curl -C - http://apache.osuosl.org/zookeeper/zookeeper-3.4.5/zookeeper-3.4.5.tar.gz | tar -zx
+    - mv $HOME/zookeeper-3.4.5 $HOME/zookeeper
+    - chmod a+x $HOME/zookeeper/bin/zkServer.sh
+    - popd
 
 after_install:
     # Pythonic tests require
@@ -20,6 +26,7 @@ after_install:
     - ./bin/hipache -c config/config_test.json &
 
 before_script:
+    - export PATH=$HOME/zookeeper/bin:$PATH
     # Hinting - XXX should fail!
     - npm run-script hint
 

--- a/lib/drivers/zookeeper.js
+++ b/lib/drivers/zookeeper.js
@@ -1,0 +1,203 @@
+(function () {
+    'use strict';
+
+    var IDriver = require('../utils/idriver'),
+        DriverError = require('../utils/drivererror'),
+        // XXX new logging infrastructure not landed yet
+        // logger = require('../logger'),
+        util = require('util');
+
+    try {
+        var SubDriver = require('node-zookeeper-client');
+    } catch (e) {
+        // XXX new logging infrastructure not landed yet
+        // logger.error('IDriver', 'You must use `npm install node-zookeeper-client` if you want to use this adapter');
+        return;
+    }
+
+    var Zookeeper = function () {
+        // Provides slave and master url properties
+        IDriver.apply(this, arguments);
+
+        var drivers = this.drivers.map(function (u) {
+            // XXX new logging infrastructure not landed yet
+            // if (u.auth) {
+            //     logger.error('Zookeeper', 'This driver doesn\'t support authentication!!!');
+            // }
+            return (u.hostname || 'localhost') + ':' + (u.port || '2181');
+        });
+        // The principal client
+        var clientReady = false;
+        var client = new SubDriver.createClient(drivers[0]);
+        client.connect();
+
+        var prefix = '';
+        if (this.drivers[0].hash) {
+            prefix = '/' + this.drivers[0].hash.substr(1);
+        }
+
+        var connected = false;
+
+        client.on('error', function (err) {
+            // Re-emit unspecified error as is
+            this.emit(this.ERROR, new DriverError(DriverError.UNSPECIFIED, err));
+        }.bind(this));
+
+        client.once('connected', function (err) {
+            clientReady = true;
+            this.emit(this.READY, err);
+        }.bind(this));
+
+        Object.defineProperty(this, 'connected', {
+            get: function () {
+                // XXX implement me!
+                return clientReady;
+            }
+        });
+
+        var sayErr = function (err) {
+            connected = false;
+            this.emit(this.ERROR, new DriverError(DriverError.UNSPECIFIED, err));
+        }.bind(this);
+
+        this.read = function (hosts, callback) {
+            var result = [];
+            var first = hosts[0];
+            var lookup = function () {
+                var host = hosts.shift();
+                if (!host) {
+                    client.getData(prefix + '/dead/' + first, null, function (error, data) {
+                        if (error && error.getCode() !== SubDriver.Exception.NO_NODE) {
+                            sayErr(error);
+                            callback(error);
+                            return;
+                        }
+                        var deads = [];
+                        var deadNodes = JSON.parse(data ? data.toString() : '[]');
+                        for (var i in deadNodes) {
+                            var id = deadNodes[i][0];
+                            var ttl = deadNodes[i][1];
+                            if (Date.parse(ttl) > Date.now()) {
+                                deads.push(id);
+                            }
+                            // XXX implement removing expired dead entries
+                        }
+                        result.push(deads);
+                        callback(null, result);
+                        return;
+                    });
+                    return;
+                }
+                client.getData(prefix + '/frontend/' + host, null, function (error, data) {
+                    if (error && error.getCode() !== SubDriver.Exception.NO_NODE) {
+                        sayErr(error);
+                        callback(error);
+                        return;
+                    }
+                    result.push(JSON.parse(data ? data.toString() : '[]'));
+                    lookup();
+                });
+            };
+            lookup();
+        };
+
+        this.create = function (host, vhost, callback) {
+            var data = JSON.stringify([vhost]);
+            client.remove(prefix + '/frontend/' + host, function ()  {
+                client.mkdirp(prefix + '/frontend', null, function (error)  {
+                    if (error) {
+                        sayErr(error);
+                        callback(error);
+                        return;
+                    }
+                    client.create(prefix + '/frontend/' + host, new Buffer(data), function (error)  {
+                        if (error) {
+                            sayErr(error);
+                            callback(error);
+                            return;
+                        }
+                        callback(error, []);
+                    });
+                });
+            });
+        };
+
+        this.add = function (host, backend, callback) {
+            var path = prefix + '/frontend/' + host;
+            client.getData(
+                path,
+                function (error, data) {
+                    if (error) {
+                        sayErr(error);
+                        callback(error);
+                        return;
+                    }
+
+                    data = JSON.parse(data.toString());
+                    data.push(backend);
+
+                    client.setData(path, new Buffer(JSON.stringify(data)), function (error) {
+                        if (error) {
+                            sayErr(error);
+                            callback(error);
+                            return;
+                        }
+                        callback(error, []);
+                    });
+                }
+            );
+        };
+
+        this.mark = function (frontend, id, url, len, ttl, callback) {
+            var path = prefix + '/dead/' + frontend;
+            client.getData(
+                path,
+                function (error, data) {
+                    if (error && error.getCode() !== SubDriver.Exception.NO_NODE) {
+                        sayErr(error);
+                        callback(error);
+                        return;
+                    }
+                    data = JSON.parse(data ? data.toString() : '[]');
+                    data.push([id, new Date(Date.now() + ttl * 1000)]);
+
+                    if (error && error.getCode() === SubDriver.Exception.NO_NODE) {
+                        client.mkdirp(prefix + '/dead', function (error) {
+                            if (error) {
+                                sayErr(error);
+                                callback(error);
+                                return;
+                            }
+                            client.create(path, new Buffer(JSON.stringify(data)), function (error) {
+                                if (error) {
+                                    sayErr(error);
+                                    callback(error);
+                                    return;
+                                }
+                                callback(error, []);
+                            });
+                        });
+                    } else {
+                        client.setData(path, new Buffer(JSON.stringify(data)), function (error) {
+                            if (error) {
+                                sayErr(error);
+                                callback(error);
+                                return;
+                            }
+                            callback(error, []);
+                        });
+                    }
+                }
+            );
+        };
+
+        this.destructor = function () {
+            client.close();
+        };
+    };
+
+    util.inherits(Zookeeper, IDriver);
+
+    module.exports = Zookeeper;
+
+})();

--- a/package.json
+++ b/package.json
@@ -41,13 +41,14 @@
     "npmlog": "^0.0.6",
     "memcached": "^0.2.8",
     "node-etcd": "^2.0.10",
+    "node-zookeeper-client": "^0.2.1",
     "ws": "^0.4.31",
     "coveralls": "^2.10.0",
     "connect": "^2.14.3"
   },
   "scripts": {
     "start": "./bin/hipache",
-    "test": "istanbul test _mocha --report html -- test/**/*.js --reporter spec",
+    "test": "istanbul test _mocha --report html -- test/**/*.js --reporter spec --timeout 4000",
     "coveralls": "istanbul cover _mocha --report lcovonly -- test/**/*.js -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "hint": "gulp hint"
   },

--- a/test/fixtures/servers/zookeeper.js
+++ b/test/fixtures/servers/zookeeper.js
@@ -1,0 +1,18 @@
+(function () {
+    'use strict';
+
+    /**
+     * A server wrapper to manipulate Zookeeper server instances.
+     */
+
+    var Generic = require('./generic');
+    var util = require('util');
+
+    var Zookeeper = function () {
+        Generic.apply(this, ['zkServer.sh', []]);
+    };
+    
+    util.inherits(Zookeeper, Generic);
+    module.exports = Zookeeper;
+
+})();

--- a/test/unit/driver-zookeeper.js
+++ b/test/unit/driver-zookeeper.js
@@ -1,0 +1,55 @@
+(function () {
+    /*globals describe:false, before:false, after:false*/
+    'use strict';
+
+    var npmlog = require('npmlog');
+    var fs = require('fs');
+    var spawn = require('child_process').spawn;
+
+    if (process.env.NO_ZOOKEEPER) {
+        npmlog.error('Test', 'No zookeeper server on this machine! No tests, then.');
+        return;
+    }
+
+    // Useful if you want to see servers talk to you
+    //require('npmlog').level = 'silly';
+
+    // var expect = require('chai').expect;
+
+    var Driver = require('../../lib/drivers/zookeeper');
+    var Server = require('../fixtures/servers/zookeeper');
+    var testReading = require('./driver-test-reading');
+
+    var s1 = new Server();
+
+    before(function (done) {
+        fs.writeFile(process.env.HOME + '/zookeeper/zoo.cfg', ['tickTime=2000',
+            'dataDir=' + process.env.HOME + '/zookeeper/data/', 'clientPort=2182'].join('\n'), function(err) {
+            if(err) {
+                npmlog.error('Test', 'Error writing zookeeper test config: ' + err);
+            }
+        });
+        process.env.ZOO_LOG_DIR = process.env.HOME + '/zookeeper/';
+
+        // Zookeeper needs time to take-off the ground :(
+        s1.start(['start-foreground', process.env.HOME + '/zookeeper/zoo.cfg']).once('started', done);
+    });
+
+    after(function (done) {
+        s1.stop().once('stopped', function(){
+          spawn('/bin/rm', ['-rf', process.env.HOME + '/zookeeper/data/']);
+          done();
+        });
+    });
+
+    describe('Zookeeper', function () {
+        [
+            ['zookeeper://:2182'],
+            ['zookeeper://:2182/#someprefix']
+        ].forEach(function (setup) {
+            describe(setup, function () {
+                testReading(Driver, setup);
+            });
+        });
+    });
+})();


### PR DESCRIPTION
Adds a zookeeper driver that matches conventions used in the etcd, memcached, and redis libraries.  All tests pass.

Note that unit tests require zookeeper server to be started by hand on :2182 so this may not be able to be merged until it can be modified to be skipped.

Also, I don't yet clean up dead backends after the ttls have expired, I just check the ttl on read.  A future iteration should remove znodes in the dead path.
