### PR TITLE
Add secure redirect ability

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -426,6 +426,16 @@ Worker.prototype.runServer = function (config) {
         });
     };
 
+    var httpRedirect = function (req, res) {
+        // If Host header includes port make sure to rewrite to HTTPS port
+        var host = req.headers.host.replace(config.http.port, config.https.port);
+        log('Redirecting http://' + req.headers.host + req.url + ' to ' +
+            'https://' + host + req.url);
+        res.writeHead(302, {
+            'Location': ('https://' + host + req.url)});
+        res.end();
+    };
+
     // Set proxy handlers
     proxy.on('error', proxyErrorHandler);
     proxy.on('start', startHandler);
@@ -444,7 +454,13 @@ Worker.prototype.runServer = function (config) {
     // Servers creation
     config.http.bind.forEach(function (options) {
         counter++;
-        var httpServer = http.createServer(httpRequestHandler);
+        // Redirect to https if forceSecure is set
+        var httpServer;
+        if (config.server.forceSecure) {
+            httpServer = http.createServer(httpRedirect);
+        } else {
+            httpServer = http.createServer(httpRequestHandler);
+        }
         httpServer.on('connection', tcpConnectionHandler);
         httpServer.on('upgrade', wsRequestHandler);
         httpServer.listen(options.port, options.address);


### PR DESCRIPTION
Adds boolean server configuration option `forceSecure` that redirects HTTP connections to HTTPS.

I know that there have been a few discussions about redirects based on the content of the request, but this is a bit different because it allows Hipache to serve a common function of other proxies (Nginx, HAProxy, etc.) which is to redirect based on schema allowing the underlying application to be agnostic.
