### PR TITLE
Adding support to use unix socket in memcached driver

### DIFF
--- a/lib/drivers/memcached.js
+++ b/lib/drivers/memcached.js
@@ -24,7 +24,7 @@
             // if (u.auth) {
             //     logger.error('Memcached', 'This driver doesn\'t support authentication!!!');
             // }
-            return (u.hostname || '127.0.0.1') + ':' + (u.port || '11211');
+            return u.path ? u.path : (u.hostname || '127.0.0.1') + ':' + (u.port || '11211');
         });
         // The principal client
         // var clientReady = false;


### PR DESCRIPTION
A simple adjustment to add support for using the unix socket in memcached driver, usage:

``` js
{
  //...
  "driver": [
    "memcached:///var/run/memcachedjs.socket"
  ]
}
```
