### PR TITLE
Allow to configure the path to the custom error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Basic Hipache configuration is described in a json file. For example:
             "accessLog": "/var/log/hipache_access.log",
             "workers": 5,
             "maxSockets": 100,
-            "deadBackendTTL": 30
+            "deadBackendTTL": 30,
+            "staticDir": null
         },
         "http": {
             "port": 80,
@@ -69,6 +70,7 @@ master process does not serve any request. Defaults to `10` if not specified.
     * __server.maxSockets__: The maximum number of sockets which can be opened on each backend (per worker). Defaults to `100` if not specified.
     * __server.deadBackendTTL__: The number of seconds a backend is flagged as
 'dead' before retrying to proxy another request to it (doesn't apply if you are using a third-party health checker). Defaults to `30`.
+    * __server.staticDir__: The absolute path of the directory containing your custom static error pages. Default value `null` means it uses Hipache's pages.
  * __http__: specifies on which ips/ports hipache will listen for http traffic. By default, hipache listens only on 127.0.0.1:80
     * __http.port__: port to listen to for http. Defaults to `80`.
     * __http.bind__: IPv4 (or IPv6) address, or addresses to listen to. You can specify a single ip, an array of ips, or an array of objects `{address: IP, port: PORT}` if you want to use a specific port on a specific ip. Defaults to `127.0.0.1`.

--- a/config/config.json
+++ b/config/config.json
@@ -7,7 +7,8 @@
         "tcpTimeout": 30,
         "retryOnError": 3,
         "deadBackendOn500": true,
-        "httpKeepAlive": false
+        "httpKeepAlive": false,
+        "staticDir": null
     },
     "https": {
         "port": 443,

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -37,7 +37,8 @@
             retryOnError: 3,
             accessLog: "/var/log/hipache/access.log",
             httpKeepAlive: false,
-            deadBackendOn500: true
+            deadBackendOn500: true,
+            staticDir: null
         }
     };
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -178,6 +178,8 @@ Worker.prototype.runServer = function (config) {
         return null;
     };
 
+    var staticDir = config.server.staticDir || [ rootDir, 'static' ].join('/');
+
     var errorMessage = function (res, message, code) {
         // Flag the Response to know that it's an internal error message
         res.errorMessage = true;
@@ -187,7 +189,7 @@ Worker.prototype.runServer = function (config) {
         code = isNaN(code) ? 400 : parseInt(code, 10);
 
         var staticPath = function (name) {
-            return rootDir + '/static/error_' + name + '.html';
+            return [ staticDir, '/', 'error_', name, '.html' ].join('');
         };
 
         var serveFile = function (filePath) {


### PR DESCRIPTION
This PR adds a simple way to tell Hipache where to find the static error pages. It is useful when one wants to customize those pages:

``` json
  {
      "server": {
          "workers": 10,
          "maxSockets": 100,
          "deadBackendTTL": 30,
          "staticDir": "/etc/hipache/static"
      },
      "http": {
          "port": 80,
          "bind": [ "0.0.0.0" ]
      },
      "https": {
          "port": 443,
          "bind": [ "0.0.0.0" ],
          "key": "/etc/ssl/ssl.key",
          "cert": "/etc/ssl/ssl.crt"
      },
      "driver": "redis://redis"
  }
```

Not sure about the `null` default value.

Then again, test suite is broken, so I can't really add test right now, which is... annoying. Anyway, you can test this feature using my [`Hipache` image](https://registry.hub.docker.com/u/willdurand/hipache/).
