### PR TITLE
Allow to pass honorCipherOrder HTTPS option

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -106,7 +106,7 @@
         https.bind = https.bind.map(function (item) {
             item = (item instanceof Object) ? item : {address: item};
             // For each address, inherit global settings if not explicitly specified
-            ['port', 'key', 'cert', 'ca', 'ciphers', 'secureProtocol'].forEach(function (key) {
+            ['port', 'key', 'cert', 'ca', 'ciphers', 'secureProtocol', 'honorCipherOrder'].forEach(function (key) {
                 item[key] = item[key] || https[key];
             });
             // If we share the same key as global, have the passphrase as well, unless overridden


### PR DESCRIPTION
Most of the SSL options are passed, that one was missing...
