### PR TITLE
Allow to configure Redis addr/port in functional tests

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -30,7 +30,17 @@ Install the required Python dependencies:
 Running the tests
 -----------------
 
-Start Hipache:
+A `redis` server must run. For instance, you can run a Docker container:
+
+    docker run -p 6379:6379 redis
+
+**Note:** if you want to use a different port, you can set the `REDIS_PORT`
+environment variable before running the test suite. In a similar manner, the
+`REDIS_ADDRESS` environment variable allows you to configure the Redis host.
+You will also have to configure the `redis` url in the `config/config_test.json`
+file.
+
+Now, start Hipache:
 
     # at the root of the repository
     bin/hipache -c config/config_test.json
@@ -42,4 +52,4 @@ Run the tests themselves:
     # go to the test directory and invoke the tests
     cd test/functional && python -m unittest discover
 
-Remember to stop Hipache once you're done.
+Remember to stop Redis and Hipache once you're done.

--- a/test/functional/base.py
+++ b/test/functional/base.py
@@ -41,7 +41,7 @@ class TestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        self.redis = redis.StrictRedis()
+        self.redis = redis.StrictRedis(os.getenv('REDIS_ADDRESS', 'localhost'), os.getenv('REDIS_PORT', 6379))
         self.check_ready()
         self._httpd_pids = []
         self._frontends = []


### PR DESCRIPTION
This makes things a bit more "flexible".
