### PR TITLE
README.md: Mention server.staticDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,8 @@ well-configured SSL/TLS layer.
 
 When something wrong happens (e.g., a backend times out), or when a request for
 an undefined virtual host comes in, Hipache will display an error page. Those
-error pages can be customized, and a configuration parameter is available to
-specify where these custom pages are located.
+error pages can be customized, and a configuration parameter (`server.staticDir`)
+is available to specify where these custom pages are located.
 
 ### Wildcard Domains Support
 


### PR DESCRIPTION
In "Custom HTML Error Pages" section, because it took me a while to figure out what the config setting was.