### PR TITLE
Remove ['redis:///ß∞'] case of #existing-drivers

### DIFF
--- a/test/unit/factory.js
+++ b/test/unit/factory.js
@@ -11,7 +11,7 @@
     describe('Driver factory', function () {
         describe('#existing-drivers', function () {
             [
-                ['redis:'], ['memcached://'], ['etcd:'], ['etcds://'], ['redis:///ß∞'],
+                ['redis:'], ['memcached://'], ['etcd:'], ['etcds://'],
                 ['redis://', 'redis://']
             ].forEach(function (urls) {
 


### PR DESCRIPTION
It fails for some reason if Redis is not running.

Fixes #198

Before:

```
$ gulp test:unit
[21:33:09] Using gulpfile ~/dev/git-repos/hipache/gulpfile.js
[21:33:09] Starting 'test:unit'...
...
  30 passing (233ms)
  1 failing

  1) Driver factory #existing-drivers redis:///ß∞:
     Uncaught
  DriverError: Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED
      at null.<anonymous> (/Users/marca/dev/git-repos/hipache/lib/drivers/redis.js:38:35)
      at RedisClient.emit (events.js:95:17)
      at RedisClient.on_error (/Users/marca/dev/git-repos/hipache/node_modules/redis/index.js:185:10)
      at Socket.<anonymous> (/Users/marca/dev/git-repos/hipache/node_modules/redis/index.js:95:14)
      at Socket.emit (events.js:95:17)
      at net.js:441:14
      at process._tickCallback (node.js:442:13)



[21:33:09] 'test:unit' errored after 298 ms
[21:33:09] Error in plugin 'gulp-mocha'
1 test failed.
```

After:

```
$ gulp test:unit
[21:34:18] Using gulpfile ~/dev/git-repos/hipache/gulpfile.js
[21:34:18] Starting 'test:unit'...
...
  29 passing (227ms)

[21:34:18] Finished 'test:unit' after 288 ms
```