### PR TITLE
Expect redis ß∞ test to error twice

### DIFF
--- a/test/unit/factory.js
+++ b/test/unit/factory.js
@@ -28,7 +28,11 @@
 
                     var driverInstance = factory.getDriver(urls);
                     // Don't leak the drivers - so, destroy whenever they reach error or ready
-                    driverInstance.once('error', driverInstance.destructor);
+                    if (u === 'redis:///ß∞') {
+                        driverInstance.on('error', driverInstance.destructor);
+                    } else {
+                        driverInstance.once('error', driverInstance.destructor);
+                    }
                     driverInstance.once('ready', driverInstance.destructor);
 
                     expect(driverInstance).to.be.an.instanceof(driverClass);


### PR DESCRIPTION
I am not sure why it errors twice, but it does for me so allowing it to error more than once fixes #198 for me.

It would be interesting to know why it errors twice for me but I guess not for others, but I would need help with that I think, because I'm not that adept at node.

```
[marca@marca-mac2 hipache]$ gulp test:unit
[17:02:26] Using gulpfile ~/dev/git-repos/hipache/gulpfile.js
[17:02:26] Starting 'test:unit'...


  Config
    Configuration loading
      ✓ From string
      ✓ From buffer
      ✓ From object
    Broken...
      ✓ ... broken json
      ✓ ... https missing key file
      ✓ ... https missing cert file
      ✓ ... https missing ca file
      ✓ ... https missing key
      ✓ ... https missing cert
    Running as root
      ✓ Not running root test as we are not root...

  Driver factory
    #existing-drivers
      ✓ redis:
      ✓ memcached://
      ✓ etcd: (95ms)
      ✓ etcds://
      ✓ redis:///ß∞
      ✓ redis://,redis://
    #erroring-on-bogus-urls
      ✓ "nopassaran://" (unregistered) should emit error
      ✓ "bogus" (no scheme) should emit error
      ✓ drivertpl:// (which is broken) should emit error

  Logger
    #creation
      ✓ err with undefined path
      ✓ err trying to open a folder
      ✓ err trying to open file in nested non existent directory
      ✓ err trying to open file with no permissions
    #trying to log in the wrong state
      ✓ stream has been closed
    #legit logging
      ✓ empty data
      ✓ legit data

  Lru
    #dumb lru
      ✓ Get, set, del
    #real lru
      ✓ Simple get, set, del
    #real lru limits
      ✓ Reaching the number of objects limits
      ✓ Reaching the ttl (53ms)


  30 passing (220ms)

[17:02:26] Finished 'test:unit' after 280 ms
```