### PR TITLE
Better error when zookeeper fails to spawn during tests

### DIFF
--- a/test/fixtures/servers/generic.js
+++ b/test/fixtures/servers/generic.js
@@ -43,6 +43,14 @@
                 npmlog.error('Server#' + command, '', data);
             });
 
+            child.on('error', function(err) {
+              var msg = 'Failed to spawn ' +
+                        '"' + command + ' ' + args.concat(moreArgs) + '" ' +
+                        '(' + err + ')';
+              npmlog.error(msg);
+              this.emit('error', new Error(msg));
+            }.bind(this));
+
             child.on('close', function (code) {
                 npmlog.silly('Server#' + command, '', 'Done with exit code ' + code);
                 this.emit('stopped');


### PR DESCRIPTION
This makes it much easier to diagnose why the tests are failing, at least in the case of zookeeper.

Before:

    [marca@marca-mac2 hipache]$ NO_ETCD=true NO_REDIS=true NO_MEMCACHED=true gulp test:drivers
    ...
      1)  "before all" hook:
         Uncaught Error: spawn ENOENT
          at errnoException (child_process.js:1011:11)
          at Process.ChildProcess._handle.onexit (child_process.js:802:34)

After:

    [marca@marca-mac2 hipache]$ NO_ETCD=true NO_REDIS=true NO_MEMCACHED=true gulp test:drivers
    ...
      1)  "before all" hook:
         Error: Failed to spawn "zkServer.sh start-foreground,/Users/marca/zookeeper/zoo.cfg" (Error: spawn ENOENT)
          at null.<anonymous> (/Users/marca/dev/git-repos/hipache/test/fixtures/servers/generic.js:51:34)
          at ChildProcess.emit (events.js:95:17)
          at Process.ChildProcess._handle.onexit (child_process.js:818:12)

Refs: #200

Cc: @dmp42, @willdurand 