### PR TITLE
test/unit/driver-zookeeper.js: Add waits

### DIFF
--- a/test/unit/driver-zookeeper.js
+++ b/test/unit/driver-zookeeper.js
@@ -23,6 +23,7 @@
     var s1 = new Server();
 
     before(function (done) {
+        this.timeout(8000);
         fs.writeFile(process.env.HOME + '/zookeeper/zoo.cfg', ['tickTime=2000',
             'dataDir=' + process.env.HOME + '/zookeeper/data/', 'clientPort=2182'].join('\n'), function(err) {
             if(err) {
@@ -33,13 +34,13 @@
 
         // Zookeeper needs time to take-off the ground :(
         s1.start(['start-foreground', process.env.HOME + '/zookeeper/zoo.cfg']).once('started', done);
+        setTimeout(done, 1000);
     });
 
     after(function (done) {
-        s1.stop().once('stopped', function(){
-          spawn('/bin/rm', ['-rf', process.env.HOME + '/zookeeper/data/']);
-          done();
-        });
+        this.timeout(8000);
+        s1.stop();
+        setTimeout(done, 1000);
     });
 
     describe('Zookeeper', function () {


### PR DESCRIPTION
This solves timeouts I was getting in `before` and `after`.

Solves zookeeper test timeouts alluded to in #203.

```
❯ rm -rf ~/zookeeper; mkdir ~/zookeeper; NO_ETCD=true NO_REDIS=true NO_MEMCACHED=true gulp test:drivers:zookeeper
[15:07:45] Using gulpfile ~/dev/git-repos/hipache/gulpfile.js
[15:07:45] Starting 'test:drivers:zookeeper'...


ERR! Server#zkServer.sh  JMX enabled by default
ERR! Server#zkServer.sh
ERR! Server#zkServer.sh  Using config: /Users/marca/zookeeper/zoo.cfg
ERR! Server#zkServer.sh
  Zookeeper
    zookeeper://:2182
      ✓ Domain with no match, no fallback (47ms)
      ✓ Single domain with a backend
      ✓ Single domain with multiple backends
      ✓ Single domain with multiple backends and fallback
      ✓ Single domain with multiple backends and fallback plus dead
      ✓ Single domain with multiple backends and fallback plus a second dead
      ✓ ... let it expire (1502ms)
    zookeeper://:2182/#someprefix
      ✓ Domain with no match, no fallback
      ✓ Single domain with a backend
      ✓ Single domain with multiple backends
      ✓ Single domain with multiple backends and fallback
      ✓ Single domain with multiple backends and fallback plus dead
      ✓ Single domain with multiple backends and fallback plus a second dead
      ✓ ... let it expire (1504ms)


  14 passing (5s)

[15:07:51] Finished 'test:drivers:zookeeper' after 5.23 s
^C%
```

Cc: @dmp42, @willdurand 