### PR TITLE
Add Via header

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -195,6 +195,7 @@ Worker.prototype.runServer = function (config) {
         var serveFile = function (filePath) {
             var stream = fs.createReadStream(filePath);
             var headers = {
+                'Via': '1.1 ' + res.host + ' (hipache/' + hipacheVersion + ')',
                 'content-type': 'text/html',
                 'cache-control': 'no-cache',
                 'pragma': 'no-cache',
@@ -261,6 +262,8 @@ Worker.prototype.runServer = function (config) {
 
         // Patch the response object
         (function () {
+            res.host = req.headers.host;
+
             // Enable debug?
             res.debug = (req.headers['x-debug'] !== undefined);
             // Patch the res.writeHead to detect backend HTTP errors and handle


### PR DESCRIPTION
A simpler alternative to https://github.com/hipache/hipache/pull/193, which solves the problem described in #192 in a different way.

```
$ http http://my-cool-app.127.0.0.1.xip.io:8080/apps
HTTP/1.1 400 Bad Request
Connection: keep-alive
Date: Wed, 07 Jan 2015 10:59:21 GMT
Transfer-Encoding: chunked
Via: 1.1 my-cool-app.127.0.0.1.xip.io:8080 (hipache/0.4.0)
cache-control: no-cache
content-type: text/html
expires: -1
pragma: no-cache

<html>
  <head>
    <title>No Application Configured</title>
    <style>
      body { background-color: #fff; margin: 0px; padding-top: 280px; text-align: center; }
      h1   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: normal; }
      h2   { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; color: #999; font-weight: normal; }
    </style>
  </head>
  <body>
    <div class="message">
      <h1>No Application Configured</h1>
      <h2>This domain is not associated with an application.</h2>
    </div>
  </body>
</html>
```