### PR TITLE
For errors, pipe file stream to response

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -205,15 +205,7 @@ Worker.prototype.runServer = function (config) {
                 headers['x-debug-version-hipache'] = hipacheVersion;
             }
             res.writeHead(code, headers);
-            stream.on('data', function (data) {
-                res.write(data);
-            });
-            stream.on('error', function () {
-                res.end();
-            });
-            stream.on('end', function () {
-                res.end();
-            });
+            stream.pipe(res);
         };
 
         var serveText = function () {


### PR DESCRIPTION
This is simpler and probably more efficient.

It might be possible to later add things to the pipe that transform (sort of like middleware).