### PR TITLE
Add link to 0.3 branch from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Ready][waffle-image]][waffle-url]
 WARNING
 -------
 
-This is the documentation for `master`. If you are running **Hipache release**,
-you should look at the documentation on the `0.3.x` branch.
+This is the documentation for `master`. If you are installing Hipache from **NPM**,
+you should look at the documentation on the [`0.3.x` branch](https://github.com/hipache/hipache/tree/0.3.1).
 
 
 What Is It?


### PR DESCRIPTION
As discussed in #162; the README is documenting the configuration for hipache master and not the latest version in NPM. I rephrased the warning message to mention NPM and also added a link to the 0.3 documentation.