### PR TITLE
Adding ability to add a UUID v4 header to each request

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ version you installed):
             "accessLog": "/var/log/hipache/access.log",
             "httpKeepAlive": false,
             "deadBackendOn500": true,
-            "staticDir": null
+            "staticDir": null,
+            "uniqueIdHeader": null
         },
         "http": {
             "port": 80,
@@ -110,6 +111,9 @@ version you installed):
     * __server.staticDir__: the absolute path of the directory containing your
       custom static error pages. Default value `null` means it uses Hipache's
       pages. Defaults to Hipache's `static/` directory.
+    * __server.uniqueIdHeader__: The name of an HTTP header that, if set,
+      contains a UUID v4 string to be passed to the backend. Defaults to `null`,
+      meaning no UUID will be generated
  * __http__: specifies on which ips/ports Hipache will listen for http traffic.
    By default, Hipache listens only on 127.0.0.1:80
     * __http.port__: port to listen to for http. Defaults to `80`.

--- a/config/config.json
+++ b/config/config.json
@@ -8,7 +8,8 @@
         "retryOnError": 3,
         "deadBackendOn500": true,
         "httpKeepAlive": false,
-        "staticDir": null
+        "staticDir": null,
+        "uniqueIdHeader": null
     },
     "http": {
         "port": 80,

--- a/config/config_test.json
+++ b/config/config_test.json
@@ -8,7 +8,8 @@
         "tcpTimeout": 5,
         "retryOnError": 0,
         "deadBackendOn500": true,
-        "httpKeepAlive": false
+        "httpKeepAlive": false,
+        "uniqueIdHeader": "X-Unique-Id"
     },
     "http": {
         "port": 1080

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -49,7 +49,8 @@
             accessLog: "/var/log/hipache/access.log",
             httpKeepAlive: false,
             deadBackendOn500: true,
-            staticDir: null
+            staticDir: null,
+            uniqueIdHeader: null,
         }
     };
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -8,7 +8,8 @@ var fs = require('fs'),
     https = require('https'),
     httpProxy = require('http-proxy'),
     cache = require('./cache'),
-    memoryMonitor = require('./memorymonitor');
+    memoryMonitor = require('./memorymonitor'),
+    uuid = require('node-uuid');
 
 var rootDir = fs.realpathSync(__dirname + '/../');
 
@@ -162,6 +163,10 @@ Worker.prototype.runServer = function (config) {
         if (req.headers['x-forwarded-port'] === undefined) {
             // FIXME: replace by the real port instead of hardcoding it
             req.headers['x-forwarded-port'] = req.connection.pair ? '443' : '80';
+        }
+        if (config.server.uniqueIdHeader !== null && 
+                req.headers[config.server.uniqueIdHeader] === undefined) {
+            req.headers[config.server.uniqueIdHeader] = uuid.v4();
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "http-proxy": "1.0.2",
     "redis": "0.10.x",
     "lru-cache": "2.5.x",
-    "minimist": "0.0.8"
+    "minimist": "0.0.8",
+    "node-uuid": "1.4.3"
   },
   "devDependencies": {
     "mocha": "1.x",


### PR DESCRIPTION
This is similar to the functionality in https://httpd.apache.org/docs/current/mod/mod_unique_id.html - if enabled, it generates a UUID v4 (random) that is passed along to the backend.  Along with the other headers, if this is already set, it does not generate another one.  