### PR TITLE
Updated http-proxy to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "http-proxy": "1.0.2",
+    "http-proxy": "latest",
     "redis": "0.10.x",
     "lru-cache": "2.5.x",
     "minimist": "0.0.8"


### PR DESCRIPTION
Updated http-proxy to latest version the 1.0.2 version always crashes on ubuntu.
