### PR TITLE
For the docker version, add an entry in /etc/hosts with the container host IP.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,12 @@ env NODE_ENV production
 # Create Hipache log directory
 RUN mkdir -p /var/log/hipache
 
+# Add run.sh start script
+copy run.sh /run.sh
+run chmod u+x /run.sh
+
 # Expose Hipache
 expose  80
 
 # Start supervisor
-cmd [ "/usr/local/bin/hipache", "-c", "/usr/local/lib/node_modules/hipache/config/config.json" ]
+cmd [ "/run.sh" ]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+dockerhostip=$(ip route show 0.0.0.0/0 | grep -Eo 'via \S+' | awk '{ print $2 }')
+
+echo "$dockerhostip dockerhost" >> /etc/hosts
+
+/usr/local/bin/hipache -c /usr/local/lib/node_modules/hipache/config/config.json


### PR DESCRIPTION
Add an entry with host machine ip in the container /etc/hosts file

This allows to use hipache docker container in front of an application installed on the host. For instance if you have a gitlab instance on your host 8080 port:
```
> rpush frontend:gitlab.dotcloud.com gitlab
> rpush frontend:gitlab.dotcloud.com http://dockerhost:8080
```