### PR TITLE
Add support for ARM64v8 architecture.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the documentation for more details about how to operate Hipache.
 
 # Latest Ubuntu LTS
-from    ubuntu:14.04
+from    ubuntu:xenial
 
 # Update
 run apt-get -y update


### PR DESCRIPTION
 - Modified Ubuntu distribution to extend support for arm64.

Signed-off-by: Odidev <odidev@puresoftware.com>